### PR TITLE
define STRICT_R_HEADERS, include float.h, adjust three constants

### DIFF
--- a/src/do_rgig1.cpp
+++ b/src/do_rgig1.cpp
@@ -1,3 +1,5 @@
+#define STRICT_R_HEADERS
+#include <float.h>
 #include <Rcpp.h>
 #include <math.h>
 #include <stdlib.h>
@@ -8,7 +10,7 @@ using namespace Rcpp;
 double do_rgig1(double lambda, double chi, double psi) {
   
   if (chi == 0){
-    chi = DOUBLE_XMIN;
+    chi = DBL_MIN;
   }
   
   if ( !(R_FINITE(lambda) && R_FINITE(chi) && R_FINITE(psi)) ||
@@ -21,7 +23,7 @@ double do_rgig1(double lambda, double chi, double psi) {
   double res;
   
   // circumvent GIGrvg in these cases
-  if (chi < 11 * DOUBLE_EPS) {
+  if (chi < 11 * DBL_EPSILON) {
     /* special cases which are basically Gamma and Inverse Gamma distribution */
     if (lambda > 0.0) {
       res = R::rgamma(lambda, 2.0/psi);
@@ -31,7 +33,7 @@ double do_rgig1(double lambda, double chi, double psi) {
     }
   }
   
-  else if (psi < 11 * DOUBLE_EPS) {
+  else if (psi < 11 * DBL_EPSILON) {
     /* special cases which are basically Gamma and Inverse Gamma distribution */
     if (lambda > 0.0) {
       res = R::rgamma(lambda, 2.0/psi);  // fixed

--- a/src/do_rgig1.h
+++ b/src/do_rgig1.h
@@ -1,6 +1,7 @@
 #ifndef DO_RGIG1_H
 #define DO_RGIG1_H
 
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 
 double do_rgig1(double lambda, double chi, double psi);


### PR DESCRIPTION
Dear BGVAR team,

Your CRAN package BGVAR uses Rcpp, and uses in (just one file) two definition of DOUBLE_EPS, and one of DOUBLE_XMIN, that would go away if we enabled STRICT_R_HEADERS -- as we would like to. Please see the discussion at
  https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context.

By simply including the standard header <float.h> and defining STRICT_R_HEADERS we can switch to DBL_EPSILON and DBL_MIN instead.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
  https://github.com/RcppCore/Rcpp/issues/1158
to confirm? I do of course see that you have a 2.2.0 ready. Worst case you just shipped this and it may go in the next update; best case you can still adjust 2.2.0.

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.
