### PR TITLE
fix valgrind error

### DIFF
--- a/src/BVAR_linear.cpp
+++ b/src/BVAR_linear.cpp
@@ -651,7 +651,7 @@ List BVAR_linear(arma::mat Yraw,
         sigma = Sv_para(2, mm);
         h0 = Sv_para(3, mm);
         stochvol::update_fast_sv(datastand, mu, phi, sigma, h0, cur_sv, rec, prior_spec, expert);
-        Sv_para.col(mm) = arma::colvec({mu, phi, sigma});
+        Sv_para.col(mm) = arma::colvec({mu, phi, sigma, h0});
         //Sv_draw.col(mm) = cur_sv;  // unsafe_col overwrites the original data without copying
       }else{
         a_full = a_1 + 0.5 * T;


### PR DESCRIPTION
Mistake was in 
https://github.com/mboeck11/BGVAR/commit/43a8b0368456f55a1cb8562c7dfffd797abe563e
in src/BVAR_linear.cpp about the changes in variable Sv_para and pars_store and in particular in line 451. Sv_para has 4 rows but receives an arma vector of length 3. Therefore its 4th element is uninitialized in all columns.

With this change, the example that failed on CRAN passes valgrind checks on my computer. The test is
```r
library(BGVAR)
set.seed(1)
data(eerDatasmall)
model.eer<-bgvar(Data=eerDatasmall,W=W.trade0012.small,draws=50,burnin=50,plag=1,eigen=TRUE)
```
and the command for running `R` was
```sh
R --debugger=valgrind --debugger-args='--track-origins=yes --leak-check=full --show-reachable=yes' --no-save --no-restore
```
after building and installing `BGVAR` with debug flags.